### PR TITLE
Support for non English keyboard layouts and handle keyboard shortcuts only when no text input is focused

### DIFF
--- a/content/configure.js
+++ b/content/configure.js
@@ -52,13 +52,16 @@ function configure() {
 
     // keyboard shortcut event listener
     document.body.addEventListener('keydown', e => {
+        // check if input is focused to not change speed accidentally
+        const activeElement = document.activeElement;
+        const isInput = activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA' || activeElement.isContentEditable;
+        if (isInput) return;
+
         if (e.shiftKey && e.code === 'Period') {  // physical key for '.'
-            e.preventDefault();
             e.stopPropagation();
             kbshort(true); // increase speed
         }
         else if (e.shiftKey && e.code === 'Comma') {  // physical key for ','
-            e.preventDefault();
             e.stopPropagation();
             kbshort(false); // decrease speed
         }

--- a/content/configure.js
+++ b/content/configure.js
@@ -52,13 +52,15 @@ function configure() {
 
     // keyboard shortcut event listener
     document.body.addEventListener('keydown', e => {
-        if (e.key === '>') {
+        if (e.shiftKey && e.code === 'Period') {  // physical key for '.'
+            e.preventDefault();
             e.stopPropagation();
-            kbshort(true);
+            kbshort(true); // increase speed
         }
-        else if (e.key === '<') {
+        else if (e.shiftKey && e.code === 'Comma') {  // physical key for ','
+            e.preventDefault();
             e.stopPropagation();
-            kbshort(false);
+            kbshort(false); // decrease speed
         }
     }, { capture: true });
 


### PR DESCRIPTION
Fixes #1:

- On English keyboards, `Shift` + `,` produces `<` and `Shift` + `.` produces `>`.
- On German keyboards, these combinations produce `;` and `:` respectively, leading to non-default shortcuts.

Also ensures that the speed does not accidentally change when an input element is currently in focus, i.e. when you write the character in the chat.