### PR TITLE
Support YouTube press-and-hold 2x speed

### DIFF
--- a/content/changespeed.js
+++ b/content/changespeed.js
@@ -3,14 +3,17 @@
 // speed change function
 function changeSpeed(newSpeed, layout) {
 
-	// chech if configured
+	// check if configured
 	if (!configure()) return;
 
 	if (!newSpeed) newSpeed = speed;
+	const parsedSpeed = typeof newSpeed === 'string' ? parseFloat(newSpeed) : newSpeed;
+
+	if (Number.isNaN(parsedSpeed)) return;
 
 	// set new speed
-	speed = newSpeed;
-	vid.playbackRate = newSpeed; 
+	speed = parsedSpeed;
+	vid.playbackRate = parsedSpeed;
 	setData('currentSpeed', speed);
 
 	updateLayout();

--- a/content/configure.js
+++ b/content/configure.js
@@ -67,9 +67,16 @@ function configure() {
         }
     }, { capture: true });
 
-    // update speed when switching videos
+    // update speed when switching videos and restore configured speed after YouTube's temporary overrides (e.g., press-and-hold 2x)
     vid.addEventListener('ratechange', e => {
-        changeSpeed();
+        if (vid.playbackRate === speed) return; // ignore our own updates
+
+        if (vid.playbackRate === 1 && speed !== 1) {
+            clearTimeout(rateRestoreTimeout);
+            rateRestoreTimeout = setTimeout(() => {
+                changeSpeed(speed);
+            }, 50);
+        }
     });
 
     // update speed when changing video url
@@ -96,7 +103,7 @@ function restoreSpeed() {
 
 // helper function - save settings to storage
 function setData(key, value) {
-	let object = {}
-	object[key] = value;
-	chrome.storage.sync.set(object);
+    let object = {}
+    object[key] = value;
+    chrome.storage.sync.set(object);
 }

--- a/content/content.js
+++ b/content/content.js
@@ -20,7 +20,8 @@ let configured = false;
 let player, vid, bezelText, bezelTextContainer, svgElement, menuObserver, srcObserver;
 let speedText, speedMenu;
 let timeoutBezel, timeoutMenu;
-let speed = 1; 
+let rateRestoreTimeout; // timeout for restoring speed after YouTube changes it
+let speed = 1;
 
 // try to configure
 configure();


### PR DESCRIPTION
Fixes: #6 

The temporary 2x speed increase triggered by holding down the left mouse button or the spacebar did not affect the playback rate, as the extension's speed update handler overrode those updates.

Now we let the handler change the speed that YouTube temporarily tries to set and then reset it back to our previously selected speed afterward.